### PR TITLE
fix: fetch itunes EP, Single tag and remove it

### DIFF
--- a/pth_yadg.user.js
+++ b/pth_yadg.user.js
@@ -1947,7 +1947,7 @@ factory = {
 						catalogInput = document.querySelector('#remaster_catalogue_number');
 					}
 
-					if (/itunes/.test(rawData.url)) {
+					if (/music.apple/.test(rawData.url)) {
 						const releaseTypeInput = document.querySelector('#releasetype');
 						switch (true) {
 							case /.+ - Single$/.test(rawData.title):


### PR DESCRIPTION
> The previous version of the userscript had the feature that iTunes releases with " - EP" and " - Single" appended to the release title would automatically have that text removed when the script fills in the Album title field, and it would select EP or Single from the Release type dropdown menu.